### PR TITLE
Fix font scaler for game systems with custom CSS

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -134,7 +134,7 @@ function _onWheel_imageResize(journal_win, which_dir) {
 
 
 function getTextDomElement(journal_win) {
-    let journal_editor = journal_win.getElementsByClassName('journal-entry-page')[0];
+    let journal_editor = journal_win.getElementsByClassName('journal-page-content')[0];
 
     if (!journal_editor) {
         journal_editor = journal_win.getElementsByClassName('editor-content')[0];


### PR DESCRIPTION
This allows to override journal-page's content that gets its style from a different source than inheritance, eg game system.

In my case, `Forbidden Lands` adds its own custom styling that takes precedence:
![obraz](https://github.com/user-attachments/assets/47e48b11-5c26-4ab3-8d8b-3ea087e318f6)
